### PR TITLE
Add usize impl and ExactSizeIterator for u8, u16, and u32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand-sequence"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Liam Gray <gmail@liamg.me>"]
 description = "A no-std crate for generating random sequences of unique integers in O(1) time."

--- a/README.md
+++ b/README.md
@@ -14,23 +14,13 @@ Properties:
   - `RandomSequence::n(index)` returns the output for a given position in the sequence.
 - Support for `u8`, `u16`, `u32`, `u64`, and `usize`. Outputs can be cast to `i8`, `i16`, `i32`, `i64`, and `isize` respectively.
 
-## Output Distribution
-
-Future work could include a more rigorous analysis of the output distribution. For now, the following charts demonstrate the roughly uniform distribution for `RandomSequence<u16>`.
-
-Histogram visualisation of the `RandomSequence` output distribution.
-![Histogram demonstrating uniformity of distribution](https://github.com/hoxxep/rand-sequence/raw/master/charts/histogram-u16.png)
-
-Visual scatter plot of the `RandomSequence` output.
-![Scatter plot of RandomSequence output](https://github.com/hoxxep/rand-sequence/raw/master/charts/scatter-u16.png)
-
 ## Features
 
 This crate is no-std compatible.
 
 - `default-features`: `rand`
 - `rand`: Enables the `rand(&mut RngCore)` helper methods on `RandomSequenceBuilder` and `RandomSequence` to initialize with random seeds, which requires the `rand` dependency. Can be omitted and instead manually provide seeds to the `RandomSequenceBuilder::seed()` method to instantiate.
-- `serde`: Enables serde support for `RandomSequenceBuilder`, which requires the `serde` dependency.
+- `serde`: Enables serde `Serlialize` and `Deserialize` support for `RandomSequenceBuilder`, which requires the `serde` dependency.
 
 ## Example
 
@@ -55,9 +45,20 @@ let nums: std::collections::HashSet<u16> = (0..=u16::MAX)
     .collect();
 assert_eq!(nums.len(), u16::MAX as usize + 1);
 
-// Serialise the config to reproduce is later, if the "serde" feature is enabled.
+// Serialise the config to reproduce the same sequence later. Requires the
+// "serde" feature to be enabled.
 // let config = serde_json::to_string(&sequence.config).unwrap();
 ```
+
+## Output Distribution
+
+Future work could include a more rigorous analysis of the output distribution. For now, the following charts demonstrate the roughly uniform distribution for `RandomSequence<u16>`.
+
+Histogram visualisation of the `RandomSequence` output distribution.
+![Histogram demonstrating uniformity of distribution](https://github.com/hoxxep/rand-sequence/raw/master/charts/histogram-u16.png)
+
+Visual scatter plot of the `RandomSequence` output.
+![Scatter plot of RandomSequence output](https://github.com/hoxxep/rand-sequence/raw/master/charts/scatter-u16.png)
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Properties:
   - Note that once a number has appeared in the sequence, it will not appear again. Each value in this sequence is unique.
 - Computing the value for any random index in the sequence is an O(1) operation.
   - `RandomSequence::n(index)` returns the output for a given position in the sequence.
-- Support for `u8`, `u16`, `u32`, and `u64`. Outputs can be cast to `i8`, `i16`, `i32`, and `i64` respectively.
+- Support for `u8`, `u16`, `u32`, `u64`, and `usize`. Outputs can be cast to `i8`, `i16`, `i32`, `i64`, and `isize` respectively.
 
 ## Output Distribution
 
@@ -43,9 +43,9 @@ let config = RandomSequenceBuilder::<u64>::rand(&mut OsRng);
 let mut sequence = config.into_iter();
 
 // Iterate over the sequence with next() and prev(), or index directly with n(i).
-assert_eq!(sequence.next(), sequence.n(0));
-assert_eq!(sequence.next(), sequence.n(1));
-assert_eq!(sequence.next(), sequence.n(2));
+assert_eq!(sequence.next().unwrap(), sequence.n(0));
+assert_eq!(sequence.next().unwrap(), sequence.n(1));
+assert_eq!(sequence.next().unwrap(), sequence.n(2));
 
 // Unique across the entire type, with support for u8, u16, u32, and u64.
 let sequence = RandomSequence::<u16>::rand(&mut OsRng);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -14,6 +14,7 @@ mod sequence {
         group.bench_function("n_u16", bench_n_u16);
         group.bench_function("n_u32", bench_n_u32);
         group.bench_function("n_u64", bench_n_u64);
+        group.bench_function("n_usize", bench_n_usize);
         group.bench_function("rand_u64", bench_rand_u64);
     }
 
@@ -35,6 +36,7 @@ mod sequence {
     bench_n!(bench_n_u16, u16);
     bench_n!(bench_n_u32, u32);
     bench_n!(bench_n_u64, u64);
+    bench_n!(bench_n_usize, usize);
 
     /// Compare standard random number generation time.
     fn bench_rand_u64(b: &mut Bencher) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![warn(missing_docs)]
 #![no_std]
 #[cfg(test)]
 extern crate std;

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -44,3 +44,4 @@ init_rand!(u8, tests_u8);
 init_rand!(u16, tests_u16);
 init_rand!(u32, tests_u32);
 init_rand!(u64, tests_u64);
+init_rand!(usize, tests_usize);

--- a/src/seed.rs
+++ b/src/seed.rs
@@ -19,3 +19,4 @@ seed_sequence!(u8);
 seed_sequence!(u16);
 seed_sequence!(u32);
 seed_sequence!(u64);
+seed_sequence!(usize);


### PR DESCRIPTION
In response to issue #3.

- Implement `RandomSequence<usize>`.
- Implement `ExactSizeIterator` on `u8`, `u16`, and `u32`. Cannot be implemented on `usize` and `u64` as the length of the iterator is `usize::MAX + 1`.
- `RandomSequence::next()` and `RandomSequence::prev()` now return `Option<T>` and terminate at the end of the sequence instead of wrapping.
- Add `RandomSequence::wrapping_next()` and `RandomSequence::wrapping_prev()`.
- `RandomSequence::index()` returns `Option<T>`
- Add `RandomSequence::exhausted() -> bool` and `RandomSequence::set_index()` methods.