### PR TITLE
Export `QuadraticResidue` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate std;
 
 #[doc(inline)]
-pub use crate::builder::RandomSequenceBuilder;
+pub use crate::builder::{RandomSequenceBuilder,QuadraticResidue};
 #[doc(inline)]
 pub use crate::sequence::RandomSequence;
 


### PR DESCRIPTION
Possibly an oversight?

Unless that trait is made public, one cannot make any generic wrapper of `RandomSequence`.